### PR TITLE
display special characters from the post content (e.g. éàè,...)  with <s...

### DIFF
--- a/grails-app/taglib/spud/blog/SpudBlogTagLib.groovy
+++ b/grails-app/taglib/spud/blog/SpudBlogTagLib.groovy
@@ -45,7 +45,7 @@ class SpudBlogTagLib {
 	def truncateHtml = { attrs ->
 
 		def content = attrs.value ?: ''
-		content = content.replaceAll("<(.|\n)*?>", '')
+		content = content.decodeHTML().replaceAll("<(.|\n)*?>", '')
 
 		def contentLength = attrs.length?.toInteger() ?: 500
 		if(content.size() > contentLength) {


### PR DESCRIPTION
...p:truncateHtml  taglib

added decodeHtml() first before processing de replaceAll. This is in
order to manage e.g. french accent in html  i.e. é == &eacute;  

DataBase ==> <p>Suivi des productions &eacute;closeries sur la campagne
2014/2015</p>
decodeHtml() ==> <p>Suivi des productions écloseries sur la campagne
2014/2015</p>
replaceAll ==> Suivi des productions écloseries sur la campagne
2014/2015