### PR TITLE
Spud Blog Post Form - Added field for custom meta image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ spud {
 	blog {
 		blogEnabled = true
 		newsEnabled = false
-		blogMapping = '/blog'
-		newsMapping = '/news'
+		blogMapping = 'blog'
+		newsMapping = 'news'
 		newsLayout = 'main' //Base Layout to use
 		blogLayout = 'main' //Base Layout to use
 		blogName = 'Spud Blog' //Used for rss and atom feed meta


### PR DESCRIPTION
Would be nice to be able to set the meta image property in the form for the non technical users. 
For the layout of the blog post to pick up this value it would need to be set as: 
`<meta property="og:image" content="${post.metaImage}"`

commit: ef5812d