### PR TITLE
Meta image

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ spud {
 	blog {
 		blogEnabled = true
 		newsEnabled = false
-		blogMapping = '/blog'
-		newsMapping = '/news'
+		blogMapping = 'blog'
+		newsMapping = 'news'
 		newsLayout = 'main' //Base Layout to use
 		blogLayout = 'main' //Base Layout to use
 		blogName = 'Spud Blog' //Used for rss and atom feed meta

--- a/grails-app/domain/spud/blog/SpudPost.groovy
+++ b/grails-app/domain/spud/blog/SpudPost.groovy
@@ -21,6 +21,7 @@ class SpudPost {
 	String urlName
 	String metaKeywords
 	String metaDescription
+	String metaImage
 	Integer commentsCount = 0
 	Long userId
 
@@ -57,6 +58,7 @@ class SpudPost {
     	contentProcessed nullable: true
     	metaKeywords nullable: true
     	metaDescription nullable: true
+		metaImage nullable: true
     	customFields nullable:true
     }
 

--- a/grails-app/views/spud/admin/posts/_form.gsp
+++ b/grails-app/views/spud/admin/posts/_form.gsp
@@ -98,6 +98,14 @@
 							<span class="help-block">A short description of the article. This is what appears on a search engines search result page.</span>
 						</div>
 					</div>
+
+					<div class="form-group">
+						<label for="post.metaImage" class="control-label col-sm-4">Image</label>
+						<div class="col-sm-8">
+							<g:textField name="post.metaImage" value="${post?.metaImage}" class="form-control"/>
+							<span class="help-block">Place an image url here. This field can be used for meta tag 'og:image'. To use, apply to the meta image content as ${'$'}{post.metaImage}.</span>
+						</div>
+					</div>
 			</div>
 		</div>
 		<div class="col-md-6">


### PR DESCRIPTION
This field can be used for meta tag 'og:image'. To use, apply to the meta image content as ${post.metaImage}. See form update here: http://bertram.d.pr/18Ut8